### PR TITLE
Event order

### DIFF
--- a/wildcard_pyevents/client.py
+++ b/wildcard_pyevents/client.py
@@ -105,4 +105,4 @@ class WildcardPyEventsClient(object):
 
         events_payload = map((lambda x: json.dumps(x)), events)
 
-        self.redis_client.lpush(self.logstash_redis_queue, *events_payload)
+        self.redis_client.rpush(self.logstash_redis_queue, *events_payload)


### PR DESCRIPTION
Adds timestamps to influx and logstash. Adds the events to the right and not to the left of the queue (logstash pulls from the left).
