### PR TITLE
py3 compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='wildcard_pyevents',
-      version='0.1',
+      version='0.2',
       description='The funniest joke in the world',
       url='http://github.com/trywildcard/wildcard_pyevents',
       author='Flying Circus',

--- a/wildcard_pyevents/client.py
+++ b/wildcard_pyevents/client.py
@@ -3,7 +3,6 @@
 Python client for Wildcard Events
 """
 import json
-import types
 import redis
 import datetime
 from influxdb import InfluxDBClient
@@ -58,7 +57,7 @@ class WildcardPyEventsClient(object):
         self.environment = environment
 
     def send(self, event_name, payload, type=None):
-        if not isinstance(payload, types.ListType):
+        if not isinstance(payload, list):
             payload = [payload]
 
         for event in payload:
@@ -69,18 +68,18 @@ class WildcardPyEventsClient(object):
 
         try:
             self.send_to_influx(event_name, payload)
-        except Exception, e:
+        except Exception as e:
             print("Could not send events to influx: " + json.dumps(payload))
             print(e)
 
         try:
             self.send_to_logstash(event_name, payload)
-        except Exception, e:
+        except Exception as e:
             print("Could not send events to logstash: " + json.dumps(payload))
             print(e)
 
     def send_to_influx(self, event_name, events):
-        if not isinstance(events, types.ListType):
+        if not isinstance(events, list):
             raise RuntimeError('Need a list of events')
 
         # create a timestamp in influx compatible format (ms since epoch, utc)
@@ -107,7 +106,7 @@ class WildcardPyEventsClient(object):
         self.influxdb_client.write_points(json.dumps([json_body]))
 
     def send_to_logstash(self, event_name, events):
-        if not isinstance(events, types.ListType):
+        if not isinstance(events, list):
             raise RuntimeError('Need a list of events')
 
         # create a timestamp in python-beaver compatible format


### PR DESCRIPTION
Some py3 styles.
Allow to send events only to logstash or only to influx.

New features:
- add `static_data` to every event (e.g. for version numbers)
- `force_event_namespace`: logstash has problems with conflicting types for columns. This helps to run multiple services.
- `event_name_fmt`: helps to namespace event names with service name and/or environment name
